### PR TITLE
Feature/update links to data studio

### DIFF
--- a/src/app/sub-apps/investment/views/index.html
+++ b/src/app/sub-apps/investment/views/index.html
@@ -8,6 +8,8 @@
 	{% set pageName='FDI Homepage' %}
 {% endif %}
 
+
+
 {% block page_heading %}
 <div class="grid-row">
 	<div class="column-single">
@@ -17,10 +19,16 @@
 {% endblock %}
 
 {% block page_content %}
-<p>We are currently updating the FDI performance dashboards. The latest available versions are below, use <strong>Google Chrome</strong> to open the following link:</p>
+	<p>To open the dashboard you must:</p>
+	<ul class="list list-bullet">
+		<li>Log out of all non-DIT Google accounts (e.g. Gmail).  Note: you may be logged in to your account even if Gmail isn’t open in any tab on your browser.</li>
+		<li>This dashboard works best in Google Chrome.</li>
+	</ul>
 
-<h2 class="sector-list-heading"><a target="_blank" href="https://datastudio.google.com/reporting/1UlYmDae8o3BeZo6inpLUfwZiDaZTVRfK/page/SjBc">FDI performance dashboard</a> <small>(opens in a new tab)</small></h2>
-<br>
-<p><strong>Watch this space there will be more MI Dashboards coming in early 2019.</strong></p>
+	<h2 class="sector-list-heading"><a target="_blank" href="https://datastudio.google.com/embed/reporting/1UlYmDae8o3BeZo6inpLUfwZiDaZTVRfK/page/SjBc">FDI performance dashboard</a> <small>(opens in a new tab)</small></h2>
+
+	<p>We are currently updating the FDI performance dashboards. There will be more MI Dashboards coming in early 2019.</p>
+
 
 {% endblock %}
+

--- a/src/app/views/downloads/list.html
+++ b/src/app/views/downloads/list.html
@@ -93,13 +93,65 @@
 	<div class="grid-row download-section-separator">
 		<div class="column-two-thirds">
 			<h2 class="download-section-heading">Contacts and Companies</h2>
-			<p class="download-section-message">
-				We have recently developed a function to allow users to filter contacts and download the results into a spreadsheet, you can find this within the 'contacts' tab of Data Hub. Please see the following link for guidance on how to access and use this feature.
-			</p>
-			<p><a href="https://uktrade.zendesk.com/hc/en-gb/articles/360000450678-Downloading-data-to-a-spreadsheet" target="_blank">Guidance on downloading data</a> <small>(opens in a new tab)</small></p>
 		</div>
 	</div>
 	{% endif %}
+
+	{% macro ukItems( downloadName, files, name='region' ) %}
+		<ol class="download-group-list">
+			{% for file in files %}
+				<li class="download-group-list_item">
+					<a href="{{ urls[ downloadName ]( file ) }}">
+						<span class="download-group-list_item_text1">Download -</span>
+						<span class="download-group-list_item_text2">{{ file[ name ] }}</span>
+					</a>
+					{% if file.updated -%}
+						<span class="download-group-list_item_updated">
+				(last updated {{ file.created | dateStamp }})
+			</span>
+					{%- endif %}
+				</li>
+			{% endfor %}
+		</ol>
+	{% endmacro %}
+
+	<div class="grid-row download-group-separator">
+		<div class="column-one-third">
+
+			{% if files.contacts.regions %}
+				<h3 class="download-group-heading">UK contacts by region</h3>
+				{{ ukItems( 'downloadContactsByRegionFile', files.contacts.regions ) }}
+			{% endif %}
+
+		</div>
+		<div class="column-one-third">
+
+			{% if files.companies.regions %}
+				<h3 class="download-group-heading">UK companies by region</h3>
+				{{ ukItems( 'downloadCompaniesByRegionFile', files.companies.regions ) }}
+			{% endif %}
+
+		</div>
+	</div>
+
+	<div class="grid-row download-group-separator">
+		<div class="column-one-third">
+
+			{% if files.contacts.sectors %}
+				<h3 class="download-group-heading">UK contacts by sector</h3>
+				{{ ukItems( 'downloadContactsBySectorFile', files.contacts.sectors, 'sector' ) }}
+			{% endif %}
+
+		</div>
+		<div class="column-one-third">
+
+			{% if files.companies.sectors %}
+				<h3 class="download-group-heading">UK companies by sector</h3>
+				{{ ukItems( 'downloadCompaniesBySectorFile', files.companies.sectors, 'sector' ) }}
+			{% endif %}
+
+		</div>
+	</div>
 
 
 {% endblock  %}

--- a/src/public/sass/_deprecated/elements/_lists.scss
+++ b/src/public/sass/_deprecated/elements/_lists.scss
@@ -1,0 +1,33 @@
+// Lists
+// ==========================================================================
+
+ul,
+ol {
+	list-style-type: none;
+}
+
+.list {
+	padding: 0;
+	margin-top: 5px;
+	margin-bottom: 20px;
+}
+
+.list li {
+	margin-bottom: 5px;
+}
+
+// Bulleted lists
+.list-bullet {
+	list-style-type: disc;
+	padding-left: 20px;
+}
+
+// Numbered lists
+.list-number {
+	list-style-type: decimal;
+	padding-left: 20px;
+
+	@include ie-lte(7) {
+		padding-left: 28px;
+	}
+}

--- a/src/public/sass/main.scss
+++ b/src/public/sass/main.scss
@@ -6,6 +6,7 @@
 @import '_deprecated/elements/buttons';
 @import '_deprecated/elements/forms';
 @import '_deprecated/elements/forms/form-validation';
+@import '_deprecated/elements/lists';
 
 @import '_deprecated/trade/components/button';
 


### PR DESCRIPTION
Update the message about how you view the FDI dashboard and replaced the Contacts and Companies download links that we removed on the previous pull request.