### PR TITLE
Replace data studio link with content

### DIFF
--- a/src/app/sub-apps/investment/views/index.html
+++ b/src/app/sub-apps/investment/views/index.html
@@ -19,14 +19,15 @@
 {% endblock %}
 
 {% block page_content %}
-	<p>To open the dashboard:</p>
-	<ul class="list list-bullet">
-		<li>Log out of all non-DIT Google accounts (e.g. Gmail).  Note: you may be logged in to your account even if Gmail isn’t open in any tab on your browser.</li>
-		<li>This dashboard works best in Google Chrome.</li>
-	</ul>
 
-	<h2 class="sector-list-heading"><a target="_blank" href="https://datastudio.google.com/embed/reporting/1MAJ0PVg7KbsA6ab01oeZCWuQamWTX8WU/page/SjBc">FDI performance dashboard</a> <small>(opens in a new tab)</small></h2>
+	<p>Dear Data Hub users</p>
 
+	<p>Thank you to everyone who sent feedback on the new FDI dashboard in Data Hub. We identified an access issue for some users and are working to fix this as quickly as possible.</p>
+
+	<p>If you have any questions in the meantime please contact <a href="mailto:lucas.arndell@trade.gov.uk">lucas.arndell@trade.gov.uk</a></p>
+
+	<p>Kind regards<br><br>
+		Data Hub Team</p>
 	<p><strong>We are currently updating the FDI performance dashboards. There will be more MI Dashboards coming in early 2019.</strong></p>
 {% endblock %}
 

--- a/src/app/sub-apps/investment/views/index.html
+++ b/src/app/sub-apps/investment/views/index.html
@@ -25,7 +25,7 @@
 		<li>This dashboard works best in Google Chrome.</li>
 	</ul>
 
-	<h2 class="sector-list-heading"><a target="_blank" href="https://datastudio.google.com/embed/reporting/1UlYmDae8o3BeZo6inpLUfwZiDaZTVRfK/page/SjBc">FDI performance dashboard</a> <small>(opens in a new tab)</small></h2>
+	<h2 class="sector-list-heading"><a target="_blank" href="https://datastudio.google.com/embed/reporting/1MAJ0PVg7KbsA6ab01oeZCWuQamWTX8WU/page/SjBc">FDI performance dashboard</a> <small>(opens in a new tab)</small></h2>
 
 	<p><strong>We are currently updating the FDI performance dashboards. There will be more MI Dashboards coming in early 2019.</strong></p>
 {% endblock %}


### PR DESCRIPTION
We need to replace the data studio link with new content explaining an access issue to data studio as not everyone can access it.