### PR TITLE
Update new link to Google data studio

### DIFF
--- a/src/app/sub-apps/investment/views/index.html
+++ b/src/app/sub-apps/investment/views/index.html
@@ -19,15 +19,14 @@
 {% endblock %}
 
 {% block page_content %}
+	<p>To open the dashboard:</p>
+	<ul class="list list-bullet">
+		<li>Log out of all non-DIT Google accounts (e.g. Gmail).  Note: you may be logged in to your account even if Gmail isn’t open in any tab on your browser.</li>
+		<li>This dashboard works best in Google Chrome.</li>
+	</ul>
 
-	<p>Dear Data Hub users</p>
+	<h2 class="sector-list-heading"><a target="_blank" href="https://www.google.com/a/data.trade.gov.uk/ServiceLogin?continue=https://datastudio.google.com/embed/reporting/1MAJ0PVg7KbsA6ab01oeZCWuQamWTX8WU/page/SjBc">FDI performance dashboard</a> <small>(opens in a new tab)</small></h2>
 
-	<p>Thank you to everyone who sent feedback on the new FDI dashboard in Data Hub. We identified an access issue for some users and are working to fix this as quickly as possible.</p>
-
-	<p>If you have any questions in the meantime please contact <a href="mailto:lucas.arndell@trade.gov.uk">lucas.arndell@trade.gov.uk</a></p>
-
-	<p>Kind regards<br><br>
-		Data Hub Team</p>
 	<p><strong>We are currently updating the FDI performance dashboards. There will be more MI Dashboards coming in early 2019.</strong></p>
 {% endblock %}
 


### PR DESCRIPTION
Content on the FDI performance page needs updating as we now have a link to Google data studio that works for all our users.