### PR TITLE
Add new UK region links to Google data studio

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "export-wins-ui-mi",
-  "version": "7.10.13",
+  "version": "7.10.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "export-wins-ui-mi",
-  "version": "7.10.13",
+  "version": "7.10.14",
   "description": "An MI dashboard for Data Hub",
   "main": "server.js",
   "engines": {

--- a/src/app/sub-apps/investment/views/index.html
+++ b/src/app/sub-apps/investment/views/index.html
@@ -37,7 +37,7 @@
 
 
 	<div class="grid-row">
-		<div class="column-half">
+		<div class="column-one-third">
 			<h3 class="sector-list-heading">Overseas Regions</h3>
 			<p>All links below open in a new tab.</p>
 			<ul class="list list-bullet">
@@ -72,7 +72,7 @@
 
 		</div>
 
-		<div class="column-half">
+		<div class="column-one-third">
 			<h3 class="sector-list-heading">Sector clusters</h3>
 			<p>All links below open in a new tab.</p>
 			<ul class="list list-bullet">
@@ -97,6 +97,17 @@
 				<li><a href="https://www.google.com/a/data.trade.gov.uk/ServiceLogin?continue=https://datastudio.go
 	ogle.com/embed/reporting/1_t9TqPw1EIq-wFLORiPYfgS4AFiW8hOW/page/hgqd" target="_blank">Technology, Entrepreneurship &
 						Advanced Manufacturing</a></li>
+			</ul>
+		</div>
+
+		<div class="column-one-third">
+			<h3 class="sector-list-heading">UK Regions</h3>
+			<p>All links below open in a new tab.</p>
+			<ul class="list list-bullet">
+				<li><a href="https://www.google.com/a/data.trade.gov.uk/ServiceLogin?continue=https://datastudio.google.com/embed/reporting/1j-y1EVF_UfWLykmmA2WDPD3nkNN-eGZW/page/iFef" target="_blank">Northern Powerhouse</a></li>
+				<li><a href="https://www.google.com/a/data.trade.gov.uk/ServiceLogin?continue=https://datastudio.google.com/embed/reporting/1FkcE89MFYcXJcBUUQ8OcaRTTSZxrZA6Z/page/tref" target="_blank">Midlands Engine</a></li>
+				<li><a href="https://www.google.com/a/data.trade.gov.uk/ServiceLogin?continue=https://datastudio.google.com/embed/reporting/10bbmjC5mbZ42DPTwIBFS_EIozlKm5df-/page/tref" target="_blank">London and devolved administrations</a></li>
+				<li><a href="https://www.google.com/a/data.trade.gov.uk/ServiceLogin?continue=https://datastudio.google.com/embed/reporting/1KaJTLHrhOTutms5DosDxBAgnz1ufy3QC/page/tref" target="_blank">Southern England</a></li>
 			</ul>
 		</div>
 	</div>


### PR DESCRIPTION
Updated the FDI dashboard with new Google data studio links to UK regions.
![screenshot 2019-01-29 at 09 37 22](https://user-images.githubusercontent.com/10154302/51898744-80459600-23a9-11e9-864f-93d9fda0b31c.png)
