### PR TITLE
Update link with correct one

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "export-wins-ui-mi",
-  "version": "7.11.0",
+  "version": "7.11.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "export-wins-ui-mi",
-  "version": "7.11.0",
+  "version": "7.11.1",
   "description": "An MI dashboard for Data Hub",
   "main": "server.js",
   "engines": {

--- a/src/app/sub-apps/investment/views/annual-report-lists/2019-2020.html
+++ b/src/app/sub-apps/investment/views/annual-report-lists/2019-2020.html
@@ -145,7 +145,7 @@
 				</li>
 				<li>
 					<a
-						href="https://www.google.com/a/data.trade.gov.uk/ServiceLogin?continue=https://datastudio.google.com/u/0/reporting/1SfBxCFadbDb200R87Jc2vyg1KmJ9CKnb/page/tref/edit"
+						href="https://www.google.com/a/data.trade.gov.uk/ServiceLogin?continue=https://datastudio.google.com/embed/reporting/1SfBxCFadbDb200R87Jc2vyg1KmJ9CKnb/page/tref"
 						target="_blank"
 						>Midlands Engine</a
 					>


### PR DESCRIPTION
## Problem
The link to Midlands Engine 2019/2020 is incorrect and opens Google Data Studio in edit mode

## Solution
Use the correct link as supplied in Trello - https://trello.com/c/cpdlgUe8/680-bug-fdi-dashboard-midlands-engine-link-incorrect