### PR TITLE
Bump global header to 1.2.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -532,9 +532,9 @@
       "dev": true
     },
     "@uktrade/datahub-header": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@uktrade/datahub-header/-/datahub-header-1.2.3.tgz",
-      "integrity": "sha512-sjbuihq1N0NpXnSHD5J3BUPY0lGvbdjNY4g9BD+uoZE+Q3L9JXM5DT4Ep+Lk211tydtFJ2iAl19R0l4O5mrDrw=="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@uktrade/datahub-header/-/datahub-header-1.2.5.tgz",
+      "integrity": "sha512-QekCmcLIakFxk8h7yKvi6CBc+mhrJGw0rOkrtjyaNBt0z7TRI+vwYdnvc/ReHP5ZWipFUFb6eIPUSObs9cSUTg=="
     },
     "a-sync-waterfall": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
 	},
 	"homepage": "https://github.com/uktrade/export-wins-ui-mi#readme",
 	"dependencies": {
-		"@uktrade/datahub-header": "^1.2.3",
+		"@uktrade/datahub-header": "^1.2.5",
 		"compression": "^1.7.4",
 		"cookie-parser": "^1.4.5",
 		"csurf": "^1.11.0",


### PR DESCRIPTION
We had to update the global header to include some more accessibility fixes - see [this PR](https://github.com/uktrade/data-hub-frontend/pull/2971) for more context