### PR TITLE
Amend global HVC's filter to filter for codes only

### DIFF
--- a/src/app/controllers/controller.index.js
+++ b/src/app/controllers/controller.index.js
@@ -9,7 +9,7 @@ module.exports = function (req, res) {
 		const overseasRegionGroups = data.overseasRegionGroups.results;
 		const ukRegions = data.ukRegions.results;
 		const globalHvcs = data.globalHvcs.results.filter((hvc, index, self) =>
-			index === self.findIndex((hvc2) => hvc.name === hvc2.name)
+			index === self.findIndex((hvc2) => hvc.code === hvc2.code)
 		);
 		const summary = globalSummary.create(data.globalWins);
 		res.render('index.html', { sectorTeams, overseasRegionGroups, ukRegions, globalHvcs, summary });

--- a/src/app/views/index.html
+++ b/src/app/views/index.html
@@ -139,7 +139,7 @@
 			<ul class="global-hvc-list">
 				{% for hvc in globalHvcs %}
 					<li>
-						<a href="{{ urls.hvc( hvc.code ) }}">{{ hvc.name }}</a>
+						<a href="{{ urls.hvc( hvc.code ) }}">{{ hvc.code }}</a>
 					</li>
 				{% endfor %}
 			</ul>


### PR DESCRIPTION
We're getting an issue where the Global HVCs on the index page of the app are being duplicated. [Christoper's PR](https://github.com/uktrade/export-wins-ui-mi/pull/263) worked to remove the duplicate names, however, it's been decided that only the global HVC codes should be shown. This PR amends the filter and the template to show codes only, and filter out duplicate codes. 

To test this: 
( if you're working from scratch)
- clone the project,
- npm install, 
- run `source .env.template`
- run `node src/data/create-backend-fake-stubs.js`
- go into `src/data/fake-stubs/backend/global_hvcs/index.2017.json` and add a couple of duplicate code numbers to the results array
- run `npm run watch-fake-stub`
- you should see no duplicates 🎉 

This passes the node tests, but I couldn't get the client tests to run 😢 

Thanks! 😄 