### PR TITLE
feat: pin header to ensure latest changes do not make it to this service

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 	},
 	"homepage": "https://github.com/uktrade/export-wins-ui-mi#readme",
 	"dependencies": {
-		"@uktrade/datahub-header": "^1.2.5",
+		"@uktrade/datahub-header": "1.2.5",
 		"compression": "^1.7.4",
 		"cookie-parser": "^1.4.5",
 		"csurf": "^1.11.0",


### PR DESCRIPTION
Changes are coming to the datahub-header repo which will effectively remove the Dashboards tab (this service). However, we still want to keep this service running for now. This PR pins the datahub-header package to the current version (1.2.5) so any header changes don't show up here.

I've made a bit of a guess about potential reviewers so let me know if I've missed someone.