### PR TITLE
Bump datahub-header version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -608,9 +608,9 @@
       "dev": true
     },
     "@uktrade/datahub-header": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@uktrade/datahub-header/-/datahub-header-1.2.5.tgz",
-      "integrity": "sha512-QekCmcLIakFxk8h7yKvi6CBc+mhrJGw0rOkrtjyaNBt0z7TRI+vwYdnvc/ReHP5ZWipFUFb6eIPUSObs9cSUTg=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@uktrade/datahub-header/-/datahub-header-1.4.1.tgz",
+      "integrity": "sha512-sSFkXp4NMAwtrqE1nKMVx4xBRMTJ9PTvmZQLYUeLVxn887HvONbOFjEfLTFeIk+z6eBxLo4OB44W6eXJ9i91dg=="
     },
     "a-sync-waterfall": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 	},
 	"homepage": "https://github.com/uktrade/export-wins-ui-mi#readme",
 	"dependencies": {
-		"@uktrade/datahub-header": "1.2.5",
+		"@uktrade/datahub-header": "1.4.1",
 		"compression": "^1.7.4",
 		"cookie-parser": "^1.4.5",
 		"csurf": "^1.11.0",


### PR DESCRIPTION
Bumps [`datahub-header`](https://github.com/uktrade/datahub-header/) version whereby it fixess [this accessibility issue](https://uktrade.atlassian.net/jira/software/projects/CPS/boards/228?label=TEAM_CI&selectedIssue=CPS-128).
