### PR TITLE
Rollback datahub-header version to v1.2.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -608,9 +608,9 @@
       "dev": true
     },
     "@uktrade/datahub-header": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@uktrade/datahub-header/-/datahub-header-1.4.1.tgz",
-      "integrity": "sha512-sSFkXp4NMAwtrqE1nKMVx4xBRMTJ9PTvmZQLYUeLVxn887HvONbOFjEfLTFeIk+z6eBxLo4OB44W6eXJ9i91dg=="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@uktrade/datahub-header/-/datahub-header-1.2.5.tgz",
+      "integrity": "sha512-QekCmcLIakFxk8h7yKvi6CBc+mhrJGw0rOkrtjyaNBt0z7TRI+vwYdnvc/ReHP5ZWipFUFb6eIPUSObs9cSUTg=="
     },
     "a-sync-waterfall": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 	},
 	"homepage": "https://github.com/uktrade/export-wins-ui-mi#readme",
 	"dependencies": {
-		"@uktrade/datahub-header": "1.4.1",
+		"@uktrade/datahub-header": "1.2.5",
 		"compression": "^1.7.4",
 		"cookie-parser": "^1.4.5",
 		"csurf": "^1.11.0",


### PR DESCRIPTION
The version of the global header used in this project should be pinned at v1.2.5, as in subsequent releases the link to this service was removed (see [this PR](https://github.com/uktrade/datahub-header/pull/17) and [this PR](https://github.com/uktrade/export-wins-ui-mi/pull/277)). Therefore I'm reverting last week's upgrade.