### PR TITLE
Upgrade dependencies 2021-07-01

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
 	"requires": true,
 	"packages": {
 		"": {
-			"version": "9.0.0",
+			"version": "9.2.0",
 			"license": "ISC",
 			"dependencies": {
 				"@uktrade/datahub-header": "1.2.5",
@@ -17,6 +17,7 @@
 				"jsonwebtoken": "^8.5.1",
 				"morgan": "^1.10.0",
 				"normalize-strings": "1.1.0",
+				"normalize-url": "^4.5.1",
 				"nunjucks": "^3.2.1",
 				"random-int": "^2.0.1",
 				"raven": "^2.6.4",
@@ -7773,7 +7774,6 @@
 			"version": "4.5.1",
 			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
 			"integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -17988,8 +17988,7 @@
 		"normalize-url": {
 			"version": "4.5.1",
 			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
-			"integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
-			"dev": true
+			"integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA=="
 		},
 		"now-and-later": {
 			"version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
 		"jsonwebtoken": "^8.5.1",
 		"morgan": "^1.10.0",
 		"normalize-strings": "1.1.0",
+		"normalize-url": "^4.5.1",
 		"nunjucks": "^3.2.1",
 		"random-int": "^2.0.1",
 		"raven": "^2.6.4",


### PR DESCRIPTION
[Upgrade normalize-url to version 4.5.1 or later](https://github.com/uktrade/export-wins-ui-mi/security/dependabot/package-lock.json/normalize-url/open).