### PR TITLE
Update npm dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -607,9 +607,9 @@
 			}
 		},
 		"node_modules/@gulp-sourcemaps/identity-map/node_modules/postcss": {
-			"version": "7.0.35",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-			"integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+			"version": "7.0.36",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+			"integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
 			"dev": true,
 			"dependencies": {
 				"chalk": "^2.4.2",
@@ -618,6 +618,10 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/postcss/"
 			}
 		},
 		"node_modules/@gulp-sourcemaps/identity-map/node_modules/source-map": {
@@ -1867,39 +1871,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/caching-transform/node_modules/make-dir": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-			"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-			"dev": true,
-			"dependencies": {
-				"semver": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/caching-transform/node_modules/semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver.js"
-			}
-		},
-		"node_modules/caching-transform/node_modules/write-file-atomic": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-			"integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
-			"dev": true,
-			"dependencies": {
-				"imurmurhash": "^0.1.4",
-				"is-typedarray": "^1.0.0",
-				"signal-exit": "^3.0.2",
-				"typedarray-to-buffer": "^3.1.5"
 			}
 		},
 		"node_modules/call-bind": {
@@ -3910,27 +3881,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/find-cache-dir/node_modules/make-dir": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-			"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-			"dev": true,
-			"dependencies": {
-				"semver": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/find-cache-dir/node_modules/semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/find-up": {
@@ -6143,18 +6093,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/istanbul-lib-processinfo/node_modules/make-dir": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-			"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-			"dev": true,
-			"dependencies": {
-				"semver": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/istanbul-lib-processinfo/node_modules/p-map": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
@@ -6186,15 +6124,6 @@
 			},
 			"bin": {
 				"rimraf": "bin.js"
-			}
-		},
-		"node_modules/istanbul-lib-processinfo/node_modules/semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/istanbul-lib-processinfo/node_modules/shebang-command": {
@@ -6254,27 +6183,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/istanbul-lib-report/node_modules/make-dir": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-			"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-			"dev": true,
-			"dependencies": {
-				"semver": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/istanbul-lib-report/node_modules/semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/istanbul-lib-report/node_modules/supports-color": {
@@ -6468,12 +6376,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/json5/node_modules/minimist": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-			"dev": true
-		},
 		"node_modules/jsonfile": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -6539,9 +6441,9 @@
 			}
 		},
 		"node_modules/jszip": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.2.2.tgz",
-			"integrity": "sha512-NmKajvAFQpbg3taXQXr/ccS2wcucR1AZ+NtyWp2Nq7HHVsXhcJFR8p0Baf32C2yVvBylFWVeKf+WI2AnvlPhpA==",
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.7.1.tgz",
+			"integrity": "sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==",
 			"dev": true,
 			"dependencies": {
 				"lie": "~3.3.0",
@@ -7520,12 +7422,6 @@
 				"mkdirp": "bin/cmd.js"
 			}
 		},
-		"node_modules/mkdirp/node_modules/minimist": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-			"dev": true
-		},
 		"node_modules/mockdate": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/mockdate/-/mockdate-2.0.5.tgz",
@@ -8084,15 +7980,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/nyc/node_modules/get-caller-file": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-			"dev": true,
-			"engines": {
-				"node": "6.* || 8.* || >= 10.*"
-			}
-		},
 		"node_modules/nyc/node_modules/glob": {
 			"version": "7.1.6",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -8126,18 +8013,6 @@
 			"dev": true,
 			"dependencies": {
 				"p-locate": "^4.1.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/nyc/node_modules/make-dir": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-			"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-			"dev": true,
-			"dependencies": {
-				"semver": "^6.0.0"
 			},
 			"engines": {
 				"node": ">=8"
@@ -8201,15 +8076,6 @@
 			},
 			"bin": {
 				"rimraf": "bin.js"
-			}
-		},
-		"node_modules/nyc/node_modules/semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/nyc/node_modules/string-width": {
@@ -8704,9 +8570,9 @@
 			}
 		},
 		"node_modules/path-parse": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
 			"dev": true
 		},
 		"node_modules/path-root": {
@@ -10170,18 +10036,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/spawn-wrap/node_modules/make-dir": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-			"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-			"dev": true,
-			"dependencies": {
-				"semver": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/spawn-wrap/node_modules/rimraf": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -10192,15 +10046,6 @@
 			},
 			"bin": {
 				"rimraf": "bin.js"
-			}
-		},
-		"node_modules/spawn-wrap/node_modules/semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/spawn-wrap/node_modules/which": {
@@ -12130,9 +11975,9 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.35",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-					"integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+					"version": "7.0.36",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+					"integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -13147,35 +12992,6 @@
 				"make-dir": "^3.0.0",
 				"package-hash": "^4.0.0",
 				"write-file-atomic": "^3.0.0"
-			},
-			"dependencies": {
-				"make-dir": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-					"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-					"dev": true,
-					"requires": {
-						"semver": "^6.0.0"
-					}
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				},
-				"write-file-atomic": {
-					"version": "3.0.3",
-					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-					"integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
-					"dev": true,
-					"requires": {
-						"imurmurhash": "^0.1.4",
-						"is-typedarray": "^1.0.0",
-						"signal-exit": "^3.0.2",
-						"typedarray-to-buffer": "^3.1.5"
-					}
-				}
 			}
 		},
 		"call-bind": {
@@ -14836,23 +14652,6 @@
 				"commondir": "^1.0.1",
 				"make-dir": "^3.0.2",
 				"pkg-dir": "^4.1.0"
-			},
-			"dependencies": {
-				"make-dir": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-					"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-					"dev": true,
-					"requires": {
-						"semver": "^6.0.0"
-					}
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				}
 			}
 		},
 		"find-up": {
@@ -16645,15 +16444,6 @@
 						"which": "^2.0.1"
 					}
 				},
-				"make-dir": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-					"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-					"dev": true,
-					"requires": {
-						"semver": "^6.0.0"
-					}
-				},
 				"p-map": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
@@ -16677,12 +16467,6 @@
 					"requires": {
 						"glob": "^7.1.3"
 					}
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
 				},
 				"shebang-command": {
 					"version": "2.0.0",
@@ -16725,21 +16509,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"make-dir": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-					"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-					"dev": true,
-					"requires": {
-						"semver": "^6.0.0"
-					}
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 					"dev": true
 				},
 				"supports-color": {
@@ -16902,14 +16671,6 @@
 			"dev": true,
 			"requires": {
 				"minimist": "^1.2.5"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.5",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-					"dev": true
-				}
 			}
 		},
 		"jsonfile": {
@@ -16969,9 +16730,9 @@
 			}
 		},
 		"jszip": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.2.2.tgz",
-			"integrity": "sha512-NmKajvAFQpbg3taXQXr/ccS2wcucR1AZ+NtyWp2Nq7HHVsXhcJFR8p0Baf32C2yVvBylFWVeKf+WI2AnvlPhpA==",
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.7.1.tgz",
+			"integrity": "sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==",
 			"dev": true,
 			"requires": {
 				"lie": "~3.3.0",
@@ -17768,14 +17529,6 @@
 			"dev": true,
 			"requires": {
 				"minimist": "^1.2.5"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.5",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-					"dev": true
-				}
 			}
 		},
 		"mockdate": {
@@ -18232,12 +17985,6 @@
 						"path-exists": "^4.0.0"
 					}
 				},
-				"get-caller-file": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-					"dev": true
-				},
 				"glob": {
 					"version": "7.1.6",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -18265,15 +18012,6 @@
 					"dev": true,
 					"requires": {
 						"p-locate": "^4.1.0"
-					}
-				},
-				"make-dir": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-					"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-					"dev": true,
-					"requires": {
-						"semver": "^6.0.0"
 					}
 				},
 				"p-locate": {
@@ -18320,12 +18058,6 @@
 					"requires": {
 						"glob": "^7.1.3"
 					}
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
 				},
 				"string-width": {
 					"version": "4.2.0",
@@ -18713,9 +18445,9 @@
 			"dev": true
 		},
 		"path-parse": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
 			"dev": true
 		},
 		"path-root": {
@@ -19897,15 +19629,6 @@
 				"which": "^2.0.1"
 			},
 			"dependencies": {
-				"make-dir": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-					"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-					"dev": true,
-					"requires": {
-						"semver": "^6.0.0"
-					}
-				},
 				"rimraf": {
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -19914,12 +19637,6 @@
 					"requires": {
 						"glob": "^7.1.3"
 					}
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
 				},
 				"which": {
 					"version": "2.0.2",


### PR DESCRIPTION
This PR updates npm dependencies, including `path-parse` for which there is a [moderate severity security vulnerability](https://github.com/uktrade/export-wins-ui-mi/security/dependabot)
