### PR TITLE
Use resolutions to pin minimist to v1.2.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5405,6 +5405,14 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+          "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+          "dev": true
+        }
       }
     },
     "jsonfile": {
@@ -6152,12 +6160,6 @@
         "brace-expansion": "^1.1.7"
       }
     },
-    "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
-    },
     "mixin-deep": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
@@ -6186,6 +6188,14 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+          "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+          "dev": true
+        }
       }
     },
     "mockdate": {
@@ -7573,6 +7583,12 @@
         "strip-json-comments": "~2.0.1"
       },
       "dependencies": {
+        "minimist": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+          "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+          "dev": true
+        },
         "strip-json-comments": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
 		"set-value": "4.0.1",
 		"json-schema": "0.4.0",
 		"ansi-regex": "5.0.1",
-		"yargs-parser": "5.0.1"
+		"yargs-parser": "5.0.1",
+		"minimist": "^1.2.6"
 	}
 }


### PR DESCRIPTION
This PR adds minimist to the resolutions list, to ensure that only versions higher than 1.2.6 are used.
Minimist is a transient dependency.